### PR TITLE
ユーザー管理機能を追加

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -14,3 +14,7 @@
  *= require_tree .
  *= require_self
  */
+
+#navi-bar {
+  background-image: linear-gradient(to right, #f78ca0 0%, #f9748f 19%, #fd868c 60%, #fe9a8b 100%);
+}

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,0 +1,49 @@
+class Admin::UsersController < ApplicationController
+  skip_before_action :login_required, only: [:new, :create,]
+
+  def new
+    @user = User.new
+  end
+
+  def create
+    @user = User.new(user_params)
+    if @user.save
+      redirect_to admin_users_path, notice: "ユーザーを新規登録しました！"
+    else
+      render :new
+    end
+  end
+
+  def show
+    @user = User.find(params[:id])
+  end
+
+  def index
+    @users = User.includes(:tasks).all.order('id')
+  end
+
+  def edit
+    @user = User.find(params[:id])
+  end
+
+  def update
+    @user = User.find(params[:id])
+    if @user.update(user_params)
+      redirect_to admin_users_path, notice: "「#{@user.name}」さんの情報を更新しました！"
+    else
+      render :edit_admin_user_path
+    end
+  end
+
+  def destroy
+    @user = User.find(params[:id])
+    @user.destroy
+    redirect_to admin_users_path, alert: "「#{@user.name}」さんの情報を削除しました！"
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:name, :email, :password, :password_confirmation)
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ApplicationRecord
   has_secure_password
   before_validation { email.downcase! }
-  has_many :tasks
+  has_many :tasks, dependent: :destroy
   validates :name, presence: true, length: { maximum: 30 }
   validates :email, presence: true, length: { maximum: 255 },
                     format: { with: /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i }

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -1,0 +1,28 @@
+<% if @user.errors.present? %>
+  <div class="container alert alert-danger my-3">
+    <ul id="error_explanation">
+      <% @user.errors.full_messages.each do |msg| %>
+        <li><%= msg %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
+
+<div class="container my-5">
+  <h1>ユーザー情報変更(管理者権限)</h1>
+  <%= form_with(model: @user, url: admin_user_path, method: :patch, local: true) do |f| %>
+    <%= f.label :name %>
+    <%= f.text_field :name %>
+
+    <%= f.label :email %>
+    <%= f.text_field :email %>
+
+    <%= f.label :password %>
+    <%= f.password_field :password %>
+
+    <%= f.label :password_confirmation %>
+    <%= f.password_field :password_confirmation %>
+
+    <%= f.submit "#{t('users.update_account')}", class: "btn btn-outline-success" %>
+  <% end %>
+</div>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,0 +1,20 @@
+<div class="container my-5">
+  <h2 class="my-3">登録ユーザー一覧</h2>
+  <%= link_to 'ユーザー登録', new_admin_user_path, class: 'btn btn-primary my-3' %>
+  <table class="table table-hover table-striped">
+    <tr>
+      <th>ユーザーID</th>
+      <th>ユーザー名</th>
+      <th colspan="2">タスク件数</th>
+    </tr>
+
+    <% @users.each do |user| %>
+      <tr>
+        <td><%= user.id %></td>
+        <td><%= user.name %></td>
+        <td><%= user.tasks.size %>件</td>
+        <td class="user_task"><%= link_to '詳細', admin_user_path(user) %></td>
+      </tr>
+    <% end %>
+  </table>
+</div>

--- a/app/views/admin/users/new.html.erb
+++ b/app/views/admin/users/new.html.erb
@@ -1,0 +1,28 @@
+<% if @user.errors.present? %>
+  <div class="container alert alert-danger my-3">
+    <ul id="error_explanation">
+      <% @user.errors.full_messages.each do |msg| %>
+        <li><%= msg %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
+
+<div class="container my-5">
+  <h1>ユーザー登録(管理者権限)</h1>
+  <%= form_with(model: @user, url: admin_users_path, local: true) do |f| %>
+    <%= f.label :name %>
+    <%= f.text_field :name %>
+
+    <%= f.label :email %>
+    <%= f.text_field :email %>
+
+    <%= f.label :password %>
+    <%= f.password_field :password %>
+
+    <%= f.label :password_confirmation %>
+    <%= f.password_field :password_confirmation %>
+
+    <%= f.submit "#{t('users.create_account')}" %>
+  <% end %>
+</div>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -1,0 +1,46 @@
+<div class="container">
+  <h1 class="my-5">ユーザ情報</h1>
+  <table class="table table-hover my-3">
+    <tbody>
+      <tr>
+        <th>ユーザーID</th>
+        <td><%= @user.id %></td>
+      </tr>
+      <tr>
+        <th>ユーザー名</th>
+        <td><%= @user.name %></td>
+      </tr>
+
+      <tr>
+        <th>メールアドレス</th>
+        <td><%= @user.email %></td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h3 class='mt-5 mb-3'>登録タスク一覧</h3>
+  <table class="table table-hover">
+    <thead>
+      <tr>
+        <th><%= t('tasks.name') %></th>
+        <th><%= t('tasks.due_date')%></th>
+        <th><%= t('tasks.status')%></th>
+        <th><%= t('tasks.priority')%></th>
+        <th colspan="3"><%= t('tasks.created_at')%></th>
+      </tr>
+    </thead>
+    <% @user.tasks.each do |task| %>
+    <tbody>
+      <tr>
+        <td><%= task.name %></td>
+        <td><%= task.due_date %></td>
+        <td><%= task.status %></td>
+        <td><%= task.priority %></td>
+        <td><%= task.created_at %></td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>
+  <%= link_to 'ユーザー編集', edit_admin_user_path(@user), class: "btn btn-outline-success" %>
+  <%= link_to 'ユーザー削除', admin_user_path(@user), class: 'btn btn-outline-danger', method: :delete, data: { confirm: "#{@user.name}を削除してよろしいですか？"} %>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,12 +10,13 @@
   </head>
 
   <body>
-    <nav class="navbar navbar-expand-sm sticky-top navbar-light p-4 border-bottom" style="background-color: #fdeff2; ">
+    <nav class="navbar navbar-expand-sm sticky-top navbar-light p-4 border-bottom" id="navi-bar">
       <div class="container-fluid">
           <a class="nav-barbrand" style="color:black;"><span>Taskmate</span></a>
         <div class="collapse navbar-collapse justify-content-end">
           <ul class="navbar-nav">
             <% if current_user %>
+              <li class="nav-item"><%= link_to '管理画面', admin_users_path, class: 'nav-link' %></li>
               <li class="nav-item"><%= link_to 'タスク一覧', tasks_path, class: 'nav-link' %></li>
               <li class="nav-item"><%= link_to 'マイページ', user_path(current_user.id), class: 'nav-link' %></li>
               <li class="nav-item"><%= link_to 'ログアウト', session_path(current_user.id), method: :delete, class: 'nav-link' %></li>

--- a/config/locales/view/task/ja.yml
+++ b/config/locales/view/task/ja.yml
@@ -1,13 +1,16 @@
 ja:
   users:
     create_account: アカウント作成
+    update_account: ユーザー情報更新
   tasks:
+    name: 名称
     to_index: 一覧へ
     to_edit: 編集
     to_delete: 削除
     due_date: 終了期限
     status: ステータス
     priority: 優先度
+    created_at: 登録日時
     index:
       task_index: タスク一覧
       name: 名称

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,11 @@ Rails.application.routes.draw do
   get 'sessions/new'
   root to: 'tasks#index'
   resources :tasks
+  namespace :admin do
+    resources :users
+  end
   resources :users, only:[:new, :create, :show]
   resources :sessions, only:[:new, :create, :destroy]
+
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -57,4 +57,40 @@ FactoryBot.define do
     status { '未着手' }
     priority { '高' }
   end
+
+  factory :seventh_task, class: Task do
+    user_id { 2 }
+    name { 'のび太が作ったデフォルトのタイトル７' }
+    description { 'のび太が作ったデフォルトのコンテント７' }
+    due_date { '2027-07-14' }
+    status { '未着手' }
+    priority { '高' }
+  end
+
+  factory :eighth_task, class: Task do
+    user_id { 2 }
+    name { 'のび太が作ったデフォルトのタイトル８' }
+    description { 'のび太が作ったデフォルトのコンテント８' }
+    due_date { '2028-08-16' }
+    status { '着手中' }
+    priority { '中' }
+  end
+
+  factory :ninth_task, class: Task do
+    user_id { 2 }
+    name { 'のび太が作ったデフォルトのタイトル９' }
+    description { 'のび太が作ったデフォルトのコンテント９' }
+    due_date { '2029-09-18' }
+    status { '未着手' }
+    priority { '低' }
+  end
+
+  factory :tenth_task, class: Task do
+    user_id { 2 }
+    name { 'のび太が作ったデフォルトのタイトル１０' }
+    description { 'のび太が作ったデフォルトのコンテント１０' }
+    due_date { '2030-10-20' }
+    status { '着手中' }
+    priority { '高' }
+  end
 end

--- a/spec/features/admin_user.spec.rb
+++ b/spec/features/admin_user.spec.rb
@@ -1,0 +1,95 @@
+require 'rails_helper'
+
+RSpec.feature "ユーザー管理機能のテスト", type: :feature do
+  background do
+    # ユーザーを３名、タスクを各２件登録
+    create(:user)
+    create(:second_user)
+    create(:third_user)
+    create(:task)
+    create(:second_task)
+    create(:third_task)
+    create(:fourth_task)
+    create(:fifth_task)
+    create(:sixth_task)
+
+    # ユーザー「のび太」でログイン
+    visit new_session_path
+    fill_in 'session_email', with: 'helpDoraemon@f.com'
+    fill_in 'session_password', with: '123456'
+    click_on 'Log in'
+  end
+
+  scenario "ナビゲーションバーの「管理画面」を押すと登録ユーザー一覧画面に移動するテスト" do
+    # 管理画面に移動
+    click_link '管理画面'
+
+    # ユーザー一覧が表示されているか確認
+    expect(page).to have_content '登録ユーザー一覧'
+    expect(page).to have_content 'のび太'
+    expect(page).to have_content 'スネ夫'
+    expect(page).to have_content 'ジャイアン'
+  end
+
+  scenario "管理者権限でユーザー登録をするテスト" do
+    # ユーザー登録画面に移動
+    visit admin_users_path
+    click_link 'ユーザー登録'
+    # 名前、メアド、パスワードを入力、アカウント作成ボタンを押す
+    fill_in 'user_name', with: 'しずか'
+    fill_in 'user_email', with: 'love_bath@f.com'
+    fill_in 'user_password', with: '123456'
+    fill_in 'user_password_confirmation', with: '123456'
+    click_on 'アカウント作成'
+
+    # 一覧画面に移動、ユーザー登録が出来ているか確認
+    expect(page).to have_content 'しずか'
+  end
+
+  scenario "ユーザー詳細画面の確認テスト" do
+    # 管理画面に移動
+    click_link '管理画面'
+
+    # ３番目の登録ユーザー画面へ
+    page.all(".user_task")[2].click_link('詳細')
+    expect(page).to have_content 'ジャイアン'
+    expect(page).to have_content 'ジャイアンが作ったデフォルトのタイトル５'
+    expect(page).to have_content 'ジャイアンが作ったデフォルトのタイトル６'
+  end
+
+  scenario "ユーザー情報変更のテスト" do
+    # 管理画面に移動
+    click_link '管理画面'
+
+    # ３番目の登録ユーザー画面へ
+    page.all(".user_task")[2].click_link('詳細')
+
+    # ユーザー情報を編集
+    click_on 'ユーザー編集'
+    fill_in 'user_name', with: 'ジャイ子'
+    fill_in 'user_email', with: 'nobita-love@f.com'
+    fill_in 'user_password', with: '123456'
+    fill_in 'user_password_confirmation', with: '123456'
+    click_on 'ユーザー情報更新'
+
+    # 一覧画面で変更が表示されているか確認
+    expect(page).not_to have_content 'ジャイアン'
+    expect(page).to have_content 'ジャイ子'
+  end
+
+  scenario "ユーザー情報削除のテスト" do
+    # 管理画面に移動
+    click_link '管理画面'
+
+    # ２番目の登録ユーザー画面へ
+    page.all(".user_task")[1].click_link('詳細')
+
+    # ユーザー情報を削除
+    click_on 'ユーザー削除'
+
+    # 一覧画面にて削除を確認
+    row = page.all('tr')
+    expect(row).not_to have_content 'スネ夫'
+    save_and_open_page
+  end
+end

--- a/spec/features/task.spec.rb
+++ b/spec/features/task.spec.rb
@@ -5,25 +5,33 @@ require 'rails_helper'
 # このRSpec.featureの右側に、「タスク管理機能」のように、テスト項目の名称を書きます（do ~ endでグループ化されています）
 RSpec.feature "タスク管理機能", type: :feature do
   background do
-    FactoryBot.create(:task)
-    FactoryBot.create(:second_task)
-    FactoryBot.create(:third_task)
-    FactoryBot.create(:fourth_task)
-    FactoryBot.create(:fifth_task)
-    FactoryBot.create(:sixth_task)
-    #Task.create!(name: 'test_task_01', description: 'testtesttest')
-    #Task.create!(name: 'test_task_02', description: 'samplesample')
+    # ユーザーを３名、タスクを各２件登録
+    create(:user)
+    create(:second_user)
+    create(:third_user)
+    create(:task)
+    create(:second_task)
+    create(:third_task)
+    create(:fourth_task)
+    create(:fifth_task)
+    create(:sixth_task)
+
+    # ユーザー「のび太」でログイン
+    visit new_session_path
+    fill_in 'session_email', with: 'helpDoraemon@f.com'
+    fill_in 'session_password', with: '123456'
+    click_on 'Log in'
   end
+
   # scenario（itのalias）の中に、確認したい各項目のテストの処理を書きます。
   scenario "タスク一覧のテスト" do
     # tasks_pathにvisitする（タスク一覧ページに遷移する）
     visit tasks_path
 
-    # visitした（到着した）expect(page)に（タスク一覧ページに）「testtesttest」「samplesample」という文字列が
+    # visitした（到着した）expect(page)に（タスク一覧ページに） 「のび太が作ったデフォルトのタイトル１と２」という文字列が
     # have_contentされているか？（含まれているか？）ということをexpectする（確認・期待する）テストを書いている
-    expect(page).to have_content 'Factoryで作ったデフォルトのタイトル６'
-    expect(page).to have_content 'Factoryで作ったデフォルトのタイトル５'
-    expect(page).to have_content 'Factoryで作ったデフォルトのタイトル４'
+    expect(page).to have_content 'のび太が作ったデフォルトのタイトル１'
+    expect(page).to have_content 'のび太が作ったデフォルトのタイトル２'
   end
 
   scenario "タスク作成のテスト" do
@@ -60,23 +68,23 @@ RSpec.feature "タスク管理機能", type: :feature do
     visit tasks_path
 
     # タスク名（リンクボタン）をクリック
-    click_link 'Factoryで作ったデフォルトのタイトル６'
+    click_link 'のび太が作ったデフォルトのタイトル１'
 
     # 詳細ページに内容が含まれているか確認
-    expect(page).to have_content 'Factoryで作ったデフォルトのコンテント６'
+    expect(page).to have_content 'のび太が作ったデフォルトのコンテント１'
 
     # 別のタスクで確認
     visit tasks_path
-    click_link 'Factoryで作ったデフォルトのタイトル３'
-    expect(page).to have_content 'Factoryで作ったデフォルトのコンテント３'
+    click_link 'のび太が作ったデフォルトのタイトル２'
+    expect(page).to have_content 'のび太が作ったデフォルトのコンテント２'
   end
 
   scenario "タスクが作成日時順に並んでいるかのテスト" do
     visit tasks_path
 
-    # ページ内のtrデータを取得、登録した６つのデータのうち、後データが上にきているか確認
+    # ページ内のtrデータを取得、登録した２つのデータのうち、後データが上にきているか確認
     row = page.all('tr')
-    expect(row[1]).to have_content 'Factoryで作ったデフォルトのタイトル６'
+    expect(row[1]).to have_content 'のび太が作ったデフォルトのタイトル２'
   end
 
   scenario "タスクを終了期限順にソートする機能のテスト" do
@@ -86,7 +94,7 @@ RSpec.feature "タスク管理機能", type: :feature do
 
     # 終了期限でソート出来ているかを確認
     row = page.all('tr')
-    expect(row[1]).to have_content '2021-06-30'
+    expect(row[1]).to have_content '2025-02-02'
   end
 
   scenario "タスクを優先度順にソートする機能のテスト" do
@@ -96,30 +104,33 @@ RSpec.feature "タスク管理機能", type: :feature do
 
     # 優先度でソート出来ているかを確認
     row = page.all('tr')
-    expect(row[1]).to have_content '高'
+    expect(row[1]).to have_content '中'
   end
 
   scenario "タスクを名前で検索する機能のテスト" do
     visit tasks_path
-    fill_in 'task_name', with: '１'
+    fill_in 'task_name', with: 'のび太が作ったデフォルトのタイトル１'
     select '', from: 'task_status'
     click_on '検索'
-    expect(page).to have_content 'Factoryで作ったデフォルトのタイトル１'
+    expect(page).to have_content ''
   end
 
   scenario "タスクをステータスで検索する機能のテスト" do
     visit tasks_path
-    select '着手中', from: 'task_status'
+    select '未着手', from: 'task_status'
     click_on '検索'
-    expect(page).to have_content 'Factoryで作ったデフォルトのタイトル２'
+    expect(page).to have_content 'のび太が作ったデフォルトのタイトル１'
   end
 
   scenario "ページネーション機能のテスト" do
     # テストデータを６件登録、１ページの最大表示件数を５件に設定
     # １件目の登録データが２ページ目に表示される事を確認する
+    create(:seventh_task)
+    create(:eighth_task)
+    create(:ninth_task)
+    create(:tenth_task)
     visit tasks_path
     click_link '次'
-    expect(page).to have_content 'Factoryで作ったデフォルトのタイトル１'
+    expect(page).to have_content 'のび太が作ったデフォルトのタイトル１'
   end
-
 end

--- a/spec/features/user.spec.rb
+++ b/spec/features/user.spec.rb
@@ -118,6 +118,5 @@ RSpec.feature "ユーザー毎のタスク管理機能", type: :feature do
     expect(page).to have_content 'のび太'
     expect(page).to have_content "#{'helpDoraemon@f.com'.downcase}"
     expect(page).to have_content '覗き見はだめよ❤️'
-    save_and_open_page
   end
 end

--- a/spec/model/task_spec.rb
+++ b/spec/model/task_spec.rb
@@ -2,13 +2,15 @@ require 'rails_helper'
 
 RSpec.describe Task, type: :model do
 
+
   it "titleが空ならバリデーションが通らない" do
-    task = Task.new(name: '')
+    task = Task.new(name: '', user_id: 1)
     expect(task).not_to be_valid
   end
 
   it "titleに内容が記載されていればバリデーションが通る" do
-    task = Task.new(name: 'なんかのタスク')
+    user = User.create(id: 1, name: 'のび太', email: 'a@a.com', password: '123456', password_confirmation: '123456')
+    task = Task.new(name: 'なんかのタスク', user_id: 1)
     expect(task).to be_valid
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -7,8 +7,13 @@ RSpec.describe User, type: :model do
 
   describe 'バリデーション' do
     it "nameが空ならバリデーションが通らない" do
-      @user.name = 'ああ'
+      @user.name = ''
       expect(@user).not_to be_valid
+    end
+
+    it "nameが入っていればバリデーションが通る" do
+      @user.name = 'ああ'
+      expect(@user).to be_valid
     end
 
     it "emailが空ならバリデーションが通らない" do


### PR DESCRIPTION
#29

- [x] 画面上に管理メニューを追加しましょう

- [x] 管理画面にはかならず /admin というURLを先頭につけるようにしましょう
routes.rb に追加する前に、あらかじめURLやルーティング名（ *_path となる名前）を想定して設計してみましょう

- [x] 管理画面でユーザ一覧・作成・更新・削除ができるようにしましょう（管理画面のビューはパーシャル化しなくて構いません）

- [x] ユーザを削除したら、そのユーザが抱えているタスクを削除するようにしてみましょう

- [x] ユーザの一覧画面で、ユーザが持っているタスクの数を表示するようにしてみましょう。その際、N+1問題を回避するための仕組みを取り入れましょう

- [x] ユーザが作成したタスクの一覧を詳細画面で見られるようにしてみましょう

- [x] 今回の実装のFeature Specを書きましょう（今回は一覧・作成・詳細・更新・削除のテストを全て書いてみましょう）
